### PR TITLE
fix: correct JAdES B-B signature structure in jades_signer

### DIFF
--- a/tools/lotl/jades_signer.py
+++ b/tools/lotl/jades_signer.py
@@ -45,16 +45,26 @@ def sign_json(
 ) -> dict[str, Any]:
     """Sign JSON payload with JAdES Compact Baseline B.
 
-    Adds a 'signature' key to the payload with the JAdES structure.
+    Adds a ``signature`` key to the payload with the JWS JSON Serialization
+    structure (RFC 7515 §7.2.2):
+
+        payload["signature"] = {
+            "protected": "<BASE64URL(UTF8(JWS Protected Header))>",  # str
+            "signature": "<BASE64URL(JWS Signature)>",               # str
+        }
+
+    The protected header contains ``alg`` (algorithm), ``x5c`` (signing
+    certificate chain, DER base64), and ``iat`` (Unix integer timestamp,
+    mandatory from 2025-07-15 per TS 119 182-1 §5.1.11 / Table 1 note a).
 
     Args:
-        payload: Unsigned JSON-serializable dict (will be modified).
+        payload: Unsigned JSON-serializable dict (will be modified in-place copy).
         key_pem: Private key in PEM format.
         cert_pem: Signing certificate in PEM format.
         algorithm: JWS algorithm (RS256, ES256, PS256).
 
     Returns:
-        Payload dict with 'signature' key added.
+        Payload dict with ``signature`` key added.
     """
     key_data = _load_pem(key_pem)
     cert_data = _load_pem(cert_pem)
@@ -114,8 +124,13 @@ def verify_json(payload: dict[str, Any]) -> dict[str, Any]:
         raise ValueError("Invalid JAdES signature structure")
 
     # Decode once to extract x5c for key loading — do NOT re-encode for the compact token
-    padding = (4 - len(protected_b64) % 4) % 4
-    protected = json.loads(base64.urlsafe_b64decode(protected_b64 + "=" * padding))
+    try:
+        padding = (4 - len(protected_b64) % 4) % 4
+        protected = json.loads(base64.urlsafe_b64decode(protected_b64 + "=" * padding))
+    except Exception as exc:
+        raise ValueError(f"Invalid JAdES signature structure: cannot decode protected header: {exc}") from exc
+    if not isinstance(protected, dict):
+        raise ValueError("Invalid JAdES signature structure: protected header is not a JSON object")
 
     x5c = protected.get("x5c") or sig.get("header", {}).get("x5c")
     if not x5c:

--- a/tools/lotl/jades_signer.py
+++ b/tools/lotl/jades_signer.py
@@ -2,6 +2,7 @@
 
 import base64
 import json
+import time
 from pathlib import Path
 from typing import Any, Union
 
@@ -68,6 +69,8 @@ def sign_json(
     header = {
         "alg": algorithm,
         "x5c": [cert_b64],
+        # TS 119 182-1 §5.1.11 / Table 1 note (a): iat mandatory from 2025-07-15; replaces sigT
+        "iat": int(time.time()),
     }
 
     jws_token = jws.JWS(json_encode(payload))
@@ -76,11 +79,12 @@ def sign_json(
     compact = jws_token.serialize(compact=True)
     parts = compact.split(".")
 
-    # JAdES signature structure (protected = JWS protected header)
+    # RFC 7515 §7.2.2: "protected" = BASE64URL(UTF8(JWS Protected Header)) — the string, not the dict.
+    # Signature covers ASCII(parts[0] || "." || parts[1]); storing the raw dict and re-encoding
+    # during verify would change key order and break §5.2 step 8 validation.
     payload["signature"] = {
-        "protected": header,
+        "protected": parts[0],
         "signature": parts[2],
-        "header": {"x5c": [cert_b64]},
     }
 
     return payload
@@ -102,11 +106,19 @@ def verify_json(payload: dict[str, Any]) -> dict[str, Any]:
     if not sig:
         raise ValueError("No signature in payload")
 
-    protected = sig.get("protected")
+    protected_b64 = sig.get("protected")
     sig_b64 = sig.get("signature")
-    x5c = sig.get("header", {}).get("x5c") or (protected.get("x5c") if protected else None)
 
-    if not protected or not sig_b64 or not x5c:
+    # protected must be the base64url string stored by sign_json (RFC 7515 §7.2.2)
+    if not isinstance(protected_b64, str) or not sig_b64:
+        raise ValueError("Invalid JAdES signature structure")
+
+    # Decode once to extract x5c for key loading — do NOT re-encode for the compact token
+    padding = (4 - len(protected_b64) % 4) % 4
+    protected = json.loads(base64.urlsafe_b64decode(protected_b64 + "=" * padding))
+
+    x5c = protected.get("x5c") or sig.get("header", {}).get("x5c")
+    if not x5c:
         raise ValueError("Invalid JAdES signature structure")
 
     cert_b64 = x5c[0] if isinstance(x5c, list) else x5c
@@ -121,11 +133,11 @@ def verify_json(payload: dict[str, Any]) -> dict[str, Any]:
     payload_copy = dict(payload)
     payload_copy.pop("signature", None)
 
-    # Rebuild JWS compact: base64url(protected).base64url(payload).signature
     def b64url_encode(data: bytes) -> str:
         return base64.urlsafe_b64encode(data).decode().rstrip("=")
 
-    protected_b64 = b64url_encode(json.dumps(protected, separators=(",", ":")).encode())
+    # Rebuild JWS compact using the original protected_b64 — must not re-encode the dict
+    # (RFC 7515 §5.2 step 8: signature covers ASCII(protected_b64 || "." || payload_b64))
     payload_b64 = b64url_encode(json_encode(payload_copy).encode())
     compact = f"{protected_b64}.{payload_b64}.{sig_b64}"
 

--- a/tools/lotl/tests/test_signing.py
+++ b/tools/lotl/tests/test_signing.py
@@ -1,5 +1,6 @@
 """Tests for XAdES and JAdES signing."""
 
+import base64
 import json
 from pathlib import Path
 
@@ -20,6 +21,19 @@ def test_jades_sign_and_verify(signing_key_and_cert: tuple[Path, Path]) -> None:
     payload = make_mock_lotl_json(sequence=1)
     signed = sign_json(payload, key_path, cert_path)
     assert "signature" in signed
+
+    sig = signed["signature"]
+
+    # RFC 7515 §7.2.2: protected must be a base64url string, not a dict
+    assert isinstance(sig["protected"], str), "protected must be a base64url string per RFC 7515 §7.2.2"
+
+    # Decode protected header and verify iat is present as integer (TS 119 182-1 §5.1.11)
+    padding = (4 - len(sig["protected"]) % 4) % 4
+    header = json.loads(base64.urlsafe_b64decode(sig["protected"] + "=" * padding))
+    assert "iat" in header, "iat must be present in protected header (TS 119 182-1 §5.1.11)"
+    assert isinstance(header["iat"], int), "iat must be an integer Unix timestamp"
+    assert header["iat"] > 0
+
     verified = verify_json(signed)
     assert "signature" not in verified
     assert verified["LoTE"]["ListAndSchemeInformation"]["LoTESequenceNumber"] == 1


### PR DESCRIPTION
- Store protected header as BASE64URL string (parts[0]), not raw dict (RFC 7515 §7.2.2 JWS JSON Serialization)
- Add iat to protected header; mandatory from 2025-07-15 (TS 119 182-1 §5.1.11 / Table 1 note a), replaces sigT
- verify_json: use stored protected_b64 directly in compact token, decode once only to extract x5c — eliminates fragile re-encoding
- Drop redundant unprotected header field; x5c already in protected