### PR TITLE
Close TL properties documentation gaps from #93

### DIFF
--- a/task3-x509-pki-etsi/etsi_trusted_lists_implementation_profile.md
+++ b/task3-x509-pki-etsi/etsi_trusted_lists_implementation_profile.md
@@ -1015,6 +1015,33 @@ Use appropriate JAdES validation library (see section 12).
 - [ ] HistoricalInformationPeriod is `65535`
 - [ ] Service history uses X509SKI (not X509Certificate)
 
+#### WRPAC Providers List
+- [ ] LoTE type URI is `http://uri.etsi.org/19602/LoTEType/EUWRPACProvidersList`
+- [ ] Status determination approach URI is correct
+- [ ] Scheme type/community/rules URI is correct
+- [ ] Service type URIs match Annex F (Issuance / Revocation)
+- [ ] Trust anchors are Access CA certificates used to validate Access Certificates
+- [ ] Next update is within 6 months
+- [ ] Signature is Compact JAdES Baseline B (JSON) or XAdES Baseline B (XML)
+
+#### WRPRC Providers List
+- [ ] LoTE type URI is `http://uri.etsi.org/19602/LoTEType/EUWRPRCProvidersList`
+- [ ] Status determination approach URI is correct
+- [ ] Scheme type/community/rules URI is correct
+- [ ] Service type URIs match Annex G (Issuance / Revocation)
+- [ ] Trust anchors are Registration Certificate Provider certificates used to validate registration certificates
+- [ ] Next update is within 6 months
+- [ ] Signature is Compact JAdES Baseline B (JSON) or XAdES Baseline B (XML)
+
+#### Registrars and Registers List (EBWOID)
+- [ ] LoTE type URI is `http://uri.etsi.org/19602/LoTEType/EURegistrarsAndRegistersList`
+- [ ] Status determination approach URI is correct
+- [ ] Scheme type/community/rules URI is correct
+- [ ] Service type URI is `http://uri.etsi.org/19602/SvcType/Register`
+- [ ] Entries identify authoritative registrars/registers used for relying-party registration and entitlement discovery
+- [ ] Next update is within 6 months
+- [ ] Signature is Compact JAdES Baseline B (JSON) or XAdES Baseline B (XML)
+
 ## Implementation Checklist
 
 ### Core Implementation

--- a/task3-x509-pki-etsi/trusted-list-extensions-credential-issuers.md
+++ b/task3-x509-pki-etsi/trusted-list-extensions-credential-issuers.md
@@ -30,6 +30,21 @@ Per [trust-infrastructure-schema.md](../task2-trust-framework/trust-infrastructu
   - Contain a **machine-readable list of allowed attestation type identifiers / namespaces** directly (making the TL entry self-contained), or
   - Contain a **pointer (URL, reference, identifier)** to the Provider's registration certificate or Registrar API, where the list of allowed attestation types is maintained.
 
+### Extensions by TL Type
+
+The `allowedAttestationType` and `registrationCertificateRef` extensions described in this document apply to Credential Issuer profiles only. `ServiceUniqueIdentifier` (see [ETSI Trusted Lists Implementation Profile](etsi_trusted_lists_implementation_profile.md) §7.2) applies to Wallet Providers. The table below makes the scope explicit for each `tl_type` used in the WP4 LoTL:
+
+| TL type | `allowedAttestationType` | `registrationCertificateRef` | `ServiceUniqueIdentifier` |
+|---------|--------------------------|------------------------------|---------------------------|
+| `pid-provider` | Yes | Optional | No |
+| `wallet-provider` | No | No | Yes (required) |
+| `pub-eaa-provider` | Yes | Optional | No |
+| `qeaa-provider` | Yes | Optional | No |
+| `eaa-provider` | Yes | Optional | No |
+| `wrpac-provider` | No | No | No |
+| `wrprc-provider` | No | No | No |
+| `ebwoid-provider` | No | No | No |
+
 ### Conflict Resolution between Trusted List, Registry, and Registration Certificate
 
 When a Trusted List entry is **self-contained** (embedded `allowedAttestationType`, no pointer), Relying Parties follow the TL metadata during validation. The TL may not reflect the current registration state if the Registry or registration certificate contains different attestation types. The following risks are not currently addressed by explicit requirements:

--- a/task4-trust-infrastructure-api/lotl-automation-and-tl-integration.md
+++ b/task4-trust-infrastructure-api/lotl-automation-and-tl-integration.md
@@ -121,6 +121,96 @@ Each `{participant_id}.json` file MUST contain:
 }
 ```
 
+#### 3.1 Metadata per TL Type
+
+The `metadata` field in the base entry format is generic (`operator_name`, `country`). Different TL types benefit from different fields; the table below defines the required and optional metadata per `tl_type`. CI validates only the base schema; per-type metadata semantics are informative unless a per-type sub-schema is added later.
+
+| TL type | Required metadata | Optional metadata | Notes |
+|---------|-------------------|-------------------|-------|
+| `pid-provider` | `operator_name`, `country` | `scheme_territory`, `scheme_operator_name` | `country` = ISO 3166-1 alpha-2 |
+| `wallet-provider` | `operator_name`, `country` | — | Same as LoTL scheme territory when EC-compiled |
+| `wrpac-provider` | `operator_name`, `country` | — | Access CA trust anchor territory |
+| `wrprc-provider` | `operator_name`, `country` | — | Registration Certificate Provider territory |
+| `pub-eaa-provider` | `operator_name`, `country` | — | EC-compiled; `country` = MS notifying |
+| `qeaa-provider` | `operator_name`, `country` | — | MS TLP; `country` = MS territory |
+| `eaa-provider` | `operator_name`, `country` | — | MS TLP; `country` = MS territory |
+| `ebwoid-provider` | `operator_name`, `country` | `registry_uri` | Registrars/Registers list |
+
+**Example TL entry for `qeaa-provider` (Member State QTSP TL):**
+
+```json
+{
+  "tl_url": "https://tsp.difi.no/national-qtsp-list.json",
+  "tl_url_xml": "https://tsp.difi.no/national-qtsp-list.xml",
+  "trust_anchor": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+  "metadata": {
+    "operator_name": "Norwegian Digitalisation Agency",
+    "country": "NO",
+    "scheme_territory": "NO"
+  }
+}
+```
+
+#### 3.2 Examples per TL Type
+
+The base entry example in §3 covers `pid-provider`. Concrete examples for other TL types follow.
+
+**`lotl/tl_entries/wallet-provider/ec.json`:**
+
+```json
+{
+  "tl_url": "https://ec.europa.eu/digital-building-blocks/wallet-providers/list.json",
+  "tl_url_xml": "https://ec.europa.eu/digital-building-blocks/wallet-providers/list.xml",
+  "trust_anchor": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+  "metadata": {
+    "operator_name": "European Commission",
+    "country": "EU"
+  }
+}
+```
+
+**`lotl/tl_entries/wrpac-provider/ms-access-ca.json`:**
+
+```json
+{
+  "tl_url": "https://access-ca.example.gov/tsl/wrpac-providers.json",
+  "trust_anchor": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+  "metadata": {
+    "operator_name": "National Access CA Authority",
+    "country": "DE"
+  }
+}
+```
+
+**`lotl/tl_entries/ebwoid-provider/ms-registry.json`:**
+
+```json
+{
+  "tl_url": "https://registry.example.gov/registrars-and-registers.json",
+  "trust_anchor": "-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----",
+  "metadata": {
+    "operator_name": "Member State Registry Authority",
+    "country": "IT",
+    "registry_uri": "https://registry.example.gov/api"
+  }
+}
+```
+
+#### 3.3 ETSI Schema per TL Type
+
+Signature validation with `trust_anchor` is implemented today. Per-type ETSI schema validation is **planned** — the table maps each `tl_type` to the ETSI standard and schema source that CI should enforce once the validator is extended (see §6.1).
+
+| `tl_type` | ETSI Standard | Schema source | CI validation |
+|-----------|---------------|---------------|---------------|
+| `pid-provider` | TS 119 602 Annex D | https://forge.etsi.org/rep/esi/x19_60201_lists_of_trusted_entities | [ ] Planned |
+| `wallet-provider` | TS 119 602 Annex E | https://forge.etsi.org/rep/esi/x19_60201_lists_of_trusted_entities | [ ] Planned |
+| `pub-eaa-provider` | TS 119 602 Annex H | https://forge.etsi.org/rep/esi/x19_60201_lists_of_trusted_entities | [ ] Planned |
+| `qeaa-provider` | TS 119 612 (national QTSP TL) | https://forge.etsi.org/rep/esi/x19_612_trusted_lists/-/raw/v2.4.1/19612_xsd.xsd | [ ] Planned |
+| `eaa-provider` | TS 119 602 Annex H | https://forge.etsi.org/rep/esi/x19_60201_lists_of_trusted_entities | [ ] Planned |
+| `wrpac-provider` | TS 119 602 Annex F | https://forge.etsi.org/rep/esi/x19_60201_lists_of_trusted_entities | [ ] Planned |
+| `wrprc-provider` | TS 119 602 Annex G | https://forge.etsi.org/rep/esi/x19_60201_lists_of_trusted_entities | [ ] Planned |
+| `ebwoid-provider` | TS 119 602 Annex I | https://forge.etsi.org/rep/esi/x19_60201_lists_of_trusted_entities | [ ] Planned |
+
 ### 4. LoTL Producer and Signer
 
 **Location**: `tools/lotl/` (see [tools/lotl/README.md](../tools/lotl/README.md))


### PR DESCRIPTION
Adds the documentation items called out in issue #93 sections 2.1, 2.3, 2.4, 2.5, and completes the §11.4 checklists left open by 2.2.

- lotl-automation-and-tl-integration.md: per-TL-type metadata table and qeaa example (§3.1), examples for wallet/wrpac/ebwoid (§3.2), ETSI-schema-per-TL-type table with planned CI status (§3.3).
- etsi_trusted_lists_implementation_profile.md: §11.4 validation checklists for WRPAC, WRPRC, and Registrars/Registers profiles (profile bodies §7.5-§7.7 were already in place).
- trusted-list-extensions-credential-issuers.md: extensions-by-TL-type applicability table covering allowedAttestationType, registrationCertificateRef, and ServiceUniqueIdentifier.

Refs #93